### PR TITLE
Use two way binding in order form inputs.

### DIFF
--- a/app/models/order.js
+++ b/app/models/order.js
@@ -1,3 +1,19 @@
+var ItemsList = can.List.extend({}, {
+  has: function(item) {
+    return this.indexOf(item) !== -1;
+  },
+
+  toggle: function(item) {
+    var index = this.indexOf(item);
+
+    if (index !== -1) {
+      this.splice(index, 1);
+    } else {
+      this.push(item);
+    }
+  }
+});
+
 var Order = can.Model.extend({
   create: 'POST /api/orders',
   findAll: 'GET /api/orders'
@@ -7,7 +23,7 @@ var Order = can.Model.extend({
       value: 'new'
     },
     items: {
-      Value: can.List
+      Value: ItemsList
     },
     total: {
       get: function() {

--- a/app/order/order.js
+++ b/app/order/order.js
@@ -30,16 +30,6 @@ var OrderViewModel = can.Map.extend({
     }
   },
 
-  toggle: function(item, add) {
-    var items = this.attr('order.items');
-    var index = items.indexOf(item);
-    if(add && index === -1) {
-      items.push(item);
-    } else {
-      items.splice(index, 1);
-    }
-  },
-
   placeOrder: function() {
     var order = this.attr('order');
     this.attr('saveStatus', order.save());

--- a/app/order/order.stache
+++ b/app/order/order.stache
@@ -28,13 +28,14 @@
         {{#eq activeTab 'lunch'}}
           <ul class="list-group panel">
             {{#each menu.lunch}}
-            <li class="list-group-item">
-              <label>
-                <input type="checkbox" (click)="{toggle this @element.0.checked}"
-                       can-value="{selected}">
-                {{name}} <span class="badge">${{price}}</span>
-              </label>
-            </li>
+              <li class="list-group-item">
+                <label>
+                  <input type="checkbox"
+                    (change)="{order.items.toggle this}"
+                    {{#if order.items.has}}checked{{/if}}>
+                  {{name}} <span class="badge">${{price}}</span>
+                </label>
+              </li>
             {{/each}}
           </ul>
         {{/eq}}
@@ -42,26 +43,27 @@
         {{#eq activeTab 'dinner'}}
           <ul class="list-group panel">
             {{#each menu.dinner}}
-            <li class="list-group-item">
-              <label>
-                <input type="checkbox" (click)="{toggle this @element.0.checked}"
-                       can-value="{selected}">
-                {{name}} <span class="badge">${{price}}</span>
-              </label>
-            </li>
+              <li class="list-group-item">
+                <label>
+                  <input type="checkbox"
+                    (change)="{order.items.toggle this}"
+                    {{#if order.items.has}}checked{{/if}}>
+                  {{name}} <span class="badge">${{price}}</span>
+                </label>
+              </li>
             {{/each}}
           </ul>
         {{/eq}}
 
         <div class="form-group">
           <label class="control-label">Name:</label>
-          <input name="name" type="text" class="form-control" (keyup)="{order.attr 'name' @element.val}">
+          <input name="name" type="text" class="form-control" can-value="{order.name}">
           <p>Please enter your name.</p>
         </div>
 
         <div class="form-group">
           <label class="control-label">Address:</label>
-          <input name="address" type="text" class="form-control" (keyup)="{order.attr 'address' @element.val}">
+          <input name="address" type="text" class="form-control" can-value="{order.address}">
           <p class="help-text">Please enter your address.</p>
         </div>
 


### PR DESCRIPTION
Closes #5.

@daffl @justinbmeyer when I tried to do `{{#if order.items.has this}}checked{{/if}}`, I got this error

![screen shot 2015-06-04 at 13 17 16](https://cloud.githubusercontent.com/assets/724877/7988884/296af5e6-0abc-11e5-8251-3f1b7ce4b1a5.png)

It works when I don't explicitly set the parameter, but it seems magic and I don't like that;  do you see why passing the parameter would cause that error?

Also @justinbmeyer, what do you think about moving the `items` helpers (`has` and `toggle`) up to the `Order` model to make our good friend Demeter happy. Something like `order.hasItem`, `order.toggleItem`.
