### PR TITLE
Remove menu tabs.

### DIFF
--- a/app/models/fixtures/restaurants.json
+++ b/app/models/fixtures/restaurants.json
@@ -12,8 +12,8 @@
     "state": "IL",
     "zip": "60045"
   },
-  "menu": {
-    "lunch": [{
+  "menu": [
+    {
       "name": "Spinach Fennel Watercress Ravioli",
       "price": 35.99
     }, {
@@ -22,8 +22,7 @@
     }, {
       "name": "Herring in Lavender Dill Reduction",
       "price": 45.99
-    }],
-    "dinner": [{
+    }, {
       "name": "Crab Pancakes with Sorrel Syrup",
       "price": 35.99
     }, {
@@ -32,8 +31,8 @@
     }, {
       "name": "Onion fries",
       "price": 15.99
-    }]
-  }
+    }
+  ]
 }, {
   "name": "Gilt bar",
   "slug": "gilt-bar",
@@ -48,8 +47,8 @@
     "state": "IL",
     "zip": "60654"
   },
-  "menu": {
-    "lunch": [{
+  "menu": [
+    {
       "name": "Ricotta Gnocchi",
       "price": 15.99
     }, {
@@ -58,8 +57,7 @@
     }, {
       "name": "Truffle Noodles",
       "price": 14.50
-    }],
-    "dinner": [{
+    }, {
       "name": "Charred Octopus",
       "price": 25.99
     }, {
@@ -68,6 +66,6 @@
     }, {
       "name": "Roasted Salmon",
       "price": 23.00
-    }]
-  }
+    }
+  ]
 }]

--- a/app/models/fixtures/spago.json
+++ b/app/models/fixtures/spago.json
@@ -12,8 +12,8 @@
     "state": "IL",
     "zip": "60045"
   },
-  "menu": {
-    "lunch": [{
+  "menu": [
+    {
       "name": "Spinach Fennel Watercress Ravioli",
       "price": 35.99
     }, {
@@ -22,8 +22,7 @@
     }, {
       "name": "Herring in Lavender Dill Reduction",
       "price": 45.99
-    }],
-    "dinner": [{
+    }, {
       "name": "Crab Pancakes with Sorrel Syrup",
       "price": 35.99
     }, {
@@ -32,6 +31,6 @@
     }, {
       "name": "Onion fries",
       "price": 15.99
-    }]
-  }
+    }
+  ]
 }

--- a/app/order/order.js
+++ b/app/order/order.js
@@ -9,9 +9,6 @@ var OrderViewModel = can.Map.extend({
     saveStatus: {
       Value: Object
     },
-    activeTab: {
-      value: 'lunch'
-    },
     restaurant: {
       get: function(old) {
         var id = this.attr('slug');
@@ -34,10 +31,6 @@ var OrderViewModel = can.Map.extend({
     var order = this.attr('order');
     this.attr('saveStatus', order.save());
     return false;
-  },
-
-  setActiveTab: function(newVal) {
-    this.attr('activeTab', newVal);
   }
 });
 

--- a/app/order/order.stache
+++ b/app/order/order.stache
@@ -6,17 +6,6 @@
       <h3>Order from {{name}}</h3>
 
       <form (submit)="placeOrder">
-        <ul class="nav nav-tabs">
-          <li (click)="{setActiveTab 'lunch'}"
-              {{#eq activeTab 'lunch'}}class="active"{{/eq}}>
-            <a href="javascript://">Lunch menu</a>
-          </li>
-          <li (click)="{setActiveTab 'dinner'}"
-              {{#eq activeTab 'dinner'}}class="active"{{/eq}}>
-            <a href="javascript://">Dinner menu</a>
-          </li>
-        </ul>
-
         <p class="info {{^if order.items.length}}text-error{{else}}text-success{{/if}}">
           {{^if order.items.length}}
             Please choose an item
@@ -25,35 +14,18 @@
           {{/if}}
         </p>
 
-        {{#eq activeTab 'lunch'}}
-          <ul class="list-group panel">
-            {{#each menu.lunch}}
-              <li class="list-group-item">
-                <label>
-                  <input type="checkbox"
-                    (change)="{order.items.toggle this}"
-                    {{#if order.items.has}}checked{{/if}}>
-                  {{name}} <span class="badge">${{price}}</span>
-                </label>
-              </li>
-            {{/each}}
-          </ul>
-        {{/eq}}
-
-        {{#eq activeTab 'dinner'}}
-          <ul class="list-group panel">
-            {{#each menu.dinner}}
-              <li class="list-group-item">
-                <label>
-                  <input type="checkbox"
-                    (change)="{order.items.toggle this}"
-                    {{#if order.items.has}}checked{{/if}}>
-                  {{name}} <span class="badge">${{price}}</span>
-                </label>
-              </li>
-            {{/each}}
-          </ul>
-        {{/eq}}
+        <ul class="list-group panel">
+          {{#each menu}}
+            <li class="list-group-item">
+              <label>
+                <input type="checkbox"
+                  (change)="{order.items.toggle this}"
+                  {{#if order.items.has}}checked{{/if}}>
+                {{name}} <span class="badge">${{price}}</span>
+              </label>
+            </li>
+          {{/each}}
+        </ul>
 
         <div class="form-group">
           <label class="control-label">Name:</label>


### PR DESCRIPTION
Render a single list of menu items instead of splitting them into lunch/dinner.

![menu](https://cloud.githubusercontent.com/assets/724877/7992178/f02f0296-0ad3-11e5-9291-b5dd2637c1d1.gif)

Closes #3.
